### PR TITLE
Improve short news search

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ HF_API_TOKEN = os.getenv("HF_API_TOKEN")
 
 # Endpoints
 HF_EMBEDDING_URL = "https://api-inference.huggingface.co/models/sentence-transformers/all-MiniLM-L6-v2"
-HF_SUMMARIZER_URL = "https://api-inference.huggingface.co/models/sshleifer/distilbart-cnn-12-6"
+HF_SUMMARIZER_URL = "https://api-inference.huggingface.co/models/google/pegasus-xsum"
 HEADERS = {"Authorization": f"Bearer {HF_API_TOKEN}"}
 
 def fetch_text_from_url(url: str) -> str:
@@ -51,6 +51,9 @@ def summarize_text(text: str) -> str:
             if isinstance(result, list) and result and 'summary_text' in result[0]:
                 print("[SUMMARY OK]", result[0]['summary_text'][:100])
                 return result[0]['summary_text']
+            elif isinstance(result, dict) and 'summary_text' in result:
+                print("[SUMMARY OK dict]", result['summary_text'][:100])
+                return result['summary_text']
             else:
                 print(f"[SUMMARY FORMAT ERROR] {result}")
                 return cleaned
@@ -63,13 +66,14 @@ def summarize_text(text: str) -> str:
 
 def get_embedding(text: str) -> list:
     try:
-        response = requests.post(HF_EMBEDDING_URL, headers=HEADERS, json={"inputs": text[:512]})
+        response = requests.post(HF_EMBEDDING_URL, headers=HEADERS, json={"inputs": [text[:512]]})
         print(f"[EMBEDDING STATUS] {response.status_code}")
         if response.status_code == 200:
-            return response.json()[0]
-        else:
-            print(f"[EMBEDDING ERROR] {response.text}")
-            return []
+            result = response.json()
+            if isinstance(result, list) and result:
+                return result[0]
+        print(f"[EMBEDDING ERROR] {response.text}")
+        return []
     except Exception as e:
         print(f"[EMBEDDING EXCEPTION] {e}")
         return []

--- a/app.py
+++ b/app.py
@@ -7,6 +7,8 @@ from urllib.parse import urlparse, quote
 from difflib import SequenceMatcher
 import dateparser
 from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
+import re
+from datetime import datetime, timedelta
 
 # Встроенный список русских стоп-слов
 RUSSIAN_STOPWORDS = [
@@ -39,6 +41,37 @@ def fetch_text_from_url(url: str) -> str:
     return '\n'.join(texts)
 
 
+def extract_additional_phrases(text: str) -> list:
+    """Extract simple patterns from short news text."""
+    extra = []
+    # фамилия + должность
+    for m in re.findall(r"([А-ЯЁ][а-яё]+)\s+(?:[\w-]+\s+)?(президент|премьер|министр|глава|депутат|сенатор|мэр|губернатор|директор|председатель)", text, flags=re.I):
+        extra.append(f"{m[0]} {m[1]}")
+    # встреча A и B
+    for m in re.findall(r"встреча\s+([А-ЯЁ][а-яё]+)\s+и\s+([А-ЯЁ][а-яё]+)", text, flags=re.I):
+        extra.append(f"встреча {m[0]} и {m[1]}")
+    # визит в город
+    for m in re.findall(r"визит\s+в\s+([А-ЯЁ][а-яё]+)", text, flags=re.I):
+        extra.append(f"визит в {m}")
+    return extra
+
+
+def filter_noise_phrases(phrases: list) -> list:
+    banned_words = {"президента", "казахстана", "владимира"}
+    endings = ("а", "я", "у", "ю", "е", "о", "ом", "ой", "ем", "ам", "ях", "ью", "ов", "ев")
+    result = []
+    for p in phrases:
+        words = p.split()
+        if len(words) == 1:
+            w = words[0].lower()
+            if w in banned_words:
+                continue
+            if len(w) < 5 or w.endswith(endings):
+                continue
+        result.append(p)
+    return result
+
+
 def extract_key_phrases(text: str, n: int = 5) -> list:
     try:
         if len(text.strip().split()) < 10:
@@ -59,6 +92,12 @@ def extract_key_phrases(text: str, n: int = 5) -> list:
         terms = vectorizer.get_feature_names_out()
         sorted_items = sorted(zip(terms, scores), key=lambda x: x[1], reverse=True)
         phrases = [term for term, _ in sorted_items[:n]]
+        # manually expand phrases for short texts
+        if len(text.split()) < 100:
+            extras = extract_additional_phrases(text)
+            if extras:
+                phrases.extend(extras)
+        phrases = list(dict.fromkeys(filter_noise_phrases(phrases)))
         return phrases
     except Exception as e:
         print(f"[ERROR in extract_key_phrases]: {e}")
@@ -83,15 +122,23 @@ def process_search(article_text: str, phrases: list) -> pd.DataFrame:
     unique_phrases = list({p for p in phrases if len(p.strip()) > 2})
 
     for phrase in unique_phrases:
-        print(f"\n🔍 Поисковая фраза: {phrase}")
         entries = search_google_news(phrase)
+        print(f"[🔍 Поиск]: \"{phrase}\" → найдено {len(entries)} результатов")
+        for e in entries[:5]:
+            print(f"    → {e.get('title')} — {e.get('link')}")
         for entry in entries[:10]:
             link = entry.get('link')
             if not link or link in seen_urls:
                 continue
             seen_urls.add(link)
             published = entry.get('published', '')
+            if not published:
+                continue
             date = dateparser.parse(published)
+            if not date:
+                continue
+            if datetime.now() - date > timedelta(days=3):
+                continue
             snippet = entry.get('title', '')
             fetched_text = fetch_text_from_url(link)
             if not fetched_text:
@@ -99,7 +146,7 @@ def process_search(article_text: str, phrases: list) -> pd.DataFrame:
             similarity = compute_similarity(article_text, fetched_text)
             print(f"→ Заголовок: {snippet}")
             print(f"→ Сходство: {similarity:.3f}")
-            if similarity < 0.5:
+            if similarity < 0.3:
                 continue
             records.append({
                 'Источник': urlparse(link).netloc,

--- a/app.py
+++ b/app.py
@@ -3,87 +3,85 @@ import requests
 from bs4 import BeautifulSoup
 import feedparser
 import pandas as pd
-from urllib.parse import urlparse, quote
+from urllib.parse import quote, urlparse
 from datetime import datetime, timedelta
 import dateparser
 import os
-import json
 import dotenv
+from newspaper import Article
 
 # Загрузка токена из .env
 dotenv.load_dotenv()
 HF_API_TOKEN = os.getenv("HF_API_TOKEN")
 
-HF_EMBEDDING_URL = "https://api-inference.huggingface.co/models/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+# Endpoints
+HF_EMBEDDING_URL = "https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+HF_SUMMARIZER_URL = "https://api-inference.huggingface.co/models/facebook/bart-large-cnn"
 HEADERS = {"Authorization": f"Bearer {HF_API_TOKEN}"}
-
 
 def fetch_text_from_url(url: str) -> str:
     try:
-        response = requests.get(url, timeout=10)
-        if response.status_code != 200:
-            return ""
-        soup = BeautifulSoup(response.text, 'html.parser')
-        texts = []
-        for tag in ['title']:
-            t = soup.find(tag)
-            if t and t.text:
-                texts.append(t.text)
-        for meta in ['description', 'og:description', 'og:title']:
-            tag = soup.find('meta', attrs={'name': meta}) or soup.find('meta', attrs={'property': meta})
-            if tag and tag.get('content'):
-                texts.append(tag['content'])
-        texts += [p.get_text(strip=True) for p in soup.find_all('p')]
-        return '\n'.join(texts)
-    except:
+        article = Article(url, language='ru')
+        article.download()
+        article.parse()
+        return article.title + "\n" + article.text
+    except Exception as e:
+        print(f"[PARSE ERROR] {e}")
         return ""
 
+def summarize_text(text: str) -> str:
+    try:
+        response = requests.post(HF_SUMMARIZER_URL, headers=HEADERS, json={"inputs": text[:1024]})
+        if response.status_code == 200:
+            return response.json()[0]['summary_text']
+        else:
+            print(f"[SUMMARY ERROR] {response.text}")
+            return ""
+    except Exception as e:
+        print(f"[SUMMARY EXCEPTION] {e}")
+        return ""
 
 def get_embedding(text: str) -> list:
     try:
-        print(f"[DEBUG] token loaded: {HF_API_TOKEN[:10]}")
-        print(f"[DEBUG] headers: {HEADERS}")
-        print(f"[DEBUG] sample input: {text[:100]}")
-        response = requests.post(HF_EMBEDDING_URL, headers=HEADERS, json={"inputs": text[:500]})
-        print(f"[HF DEBUG] Status: {response.status_code}")
+        response = requests.post(HF_EMBEDDING_URL, headers=HEADERS, json={"inputs": text[:512]})
         if response.status_code == 200:
-            output = response.json()
-            print(f"[HF DEBUG] Output sample: {output[0][:5] if isinstance(output, list) else output}")
-            return output[0] if isinstance(output, list) else []
+            return response.json()[0]
         else:
-            print(f"[HF ERROR] {response.text}")
+            print(f"[EMBEDDING ERROR] {response.text}")
             return []
     except Exception as e:
-        print(f"[HF EXCEPTION] {e}")
+        print(f"[EMBEDDING EXCEPTION] {e}")
         return []
-
 
 def cosine_similarity(a, b):
     if not a or not b or len(a) != len(b):
         return 0
-    dot = sum(i*j for i, j in zip(a, b))
-    norm_a = sum(i*i for i in a) ** 0.5
-    norm_b = sum(i*i for i in b) ** 0.5
+    dot = sum(i * j for i, j in zip(a, b))
+    norm_a = sum(i * i for i in a) ** 0.5
+    norm_b = sum(i * i for i in b) ** 0.5
     return dot / (norm_a * norm_b + 1e-8)
 
-
-def search_google_news(text: str) -> list:
-    query = quote(text[:100])
-    url = f"https://news.google.com/rss/search?q={query}&hl=ru&gl=KZ&ceid=KZ:ru"
+def search_google_news(query: str) -> list:
+    q = quote(query)
+    url = f"https://news.google.com/rss/search?q={q}&hl=ru&gl=KZ&ceid=KZ:ru"
     feed = feedparser.parse(url)
     print(f"[RSS DEBUG] Найдено {len(feed.entries)} публикаций по запросу: {query}")
     return feed.entries
 
-
 def process_semantic_search(article_text: str) -> pd.DataFrame:
-    base_embed = get_embedding(article_text)
+    summary = summarize_text(article_text)
+    if not summary:
+        st.warning("Не удалось сделать краткое содержание текста")
+        return pd.DataFrame()
+
+    base_embed = get_embedding(summary)
     if not base_embed:
-        st.warning("Embedding пустой. Проверь API или токен.")
+        st.warning("Не удалось получить embedding текста")
         return pd.DataFrame()
 
     records = []
     seen = set()
-    entries = search_google_news(article_text)
+    entries = search_google_news(summary)
 
     for entry in entries[:20]:
         link = entry.get('link')
@@ -91,48 +89,46 @@ def process_semantic_search(article_text: str) -> pd.DataFrame:
             continue
         seen.add(link)
         pub_date = dateparser.parse(entry.get('published', ''))
-        if not pub_date or (datetime.now() - pub_date.replace(tzinfo=None) > timedelta(days=3)):
+        if not pub_date or (datetime.now() - pub_date.replace(tzinfo=None) > timedelta(days=5)):
             continue
         fetched = fetch_text_from_url(link)
-        print(f"[PARSE DEBUG] Длина текста с {link}: {len(fetched)}")
         if not fetched or len(fetched) < 100:
             continue
-        cmp_embed = get_embedding(fetched[:500])
+        cmp_embed = get_embedding(fetched)
         sim = cosine_similarity(base_embed, cmp_embed)
-        print(f"[SIM DEBUG] Сходство с '{entry.get('title', '')[:40]}...': {sim:.4f}")
         if sim < 0.3:
             continue
         records.append({
             'Источник': urlparse(link).netloc,
             'Дата': pub_date.strftime('%Y-%m-%d %H:%M') if pub_date else '',
-            'Сходство': f"{sim*100:.1f}%",
+            'Сходство': f"{sim * 100:.1f}%",
             'Заголовок': entry.get('title', ''),
             'Ссылка': link,
             'similarity_value': sim,
             'date_value': pub_date
         })
+
     df = pd.DataFrame(records)
     if not df.empty:
         df = df.sort_values(by=['similarity_value', 'date_value'], ascending=[False, True])
         df = df.drop(columns=['similarity_value', 'date_value'])
     return df
 
-
 # Streamlit UI
-st.title('🧠 Семантический поиск похожих публикаций (на ИИ)')
-url = st.text_input('Ссылка на статью')
-text = st.text_area('Или вставьте текст публикации')
-if st.button('Анализ и поиск'):
+st.title('📡 Поиск первоисточника и распространения новости (ИИ)')
+url = st.text_input('Вставьте ссылку на статью')
+text = st.text_area('Или вставьте текст вручную')
+if st.button('🔍 Найти похожие публикации'):
     raw = text.strip()
     if not raw and url:
-        st.info('Парсинг текста...')
+        st.info('Парсим содержимое по ссылке...')
         raw = fetch_text_from_url(url)
     if not raw:
-        st.error('Не удалось получить текст')
+        st.error('Не удалось получить текст для анализа.')
     else:
-        st.info('Получение смыслового представления текста...')
+        st.info('Анализируем смысл текста и ищем похожее...')
         df = process_semantic_search(raw)
         if df.empty:
-            st.warning('Похожие публикации не найдены')
+            st.warning('Похожие публикации не найдены.')
         else:
             st.dataframe(df)

--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ HF_API_TOKEN = os.getenv("HF_API_TOKEN")
 
 # Endpoints
 HF_EMBEDDING_URL = "https://api-inference.huggingface.co/models/sentence-transformers/all-MiniLM-L6-v2"
-HF_SUMMARIZER_URL = "https://api-inference.huggingface.co/models/facebook/bart-large-cnn"
+HF_SUMMARIZER_URL = "https://api-inference.huggingface.co/models/sshleifer/distilbart-cnn-12-6"
 HEADERS = {"Authorization": f"Bearer {HF_API_TOKEN}"}
 
 def fetch_text_from_url(url: str) -> str:

--- a/app.py
+++ b/app.py
@@ -15,8 +15,8 @@ dotenv.load_dotenv()
 HF_API_TOKEN = os.getenv("HF_API_TOKEN")
 
 # Endpoints
-HF_EMBEDDING_URL = "https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/all-MiniLM-L6-v2"
-HF_SUMMARIZER_URL = "https://api-inference.huggingface.co/models/csebuetnlp/mT5_multilingual_XLSum"
+HF_EMBEDDING_URL = "https://api-inference.huggingface.co/models/sentence-transformers/all-MiniLM-L6-v2"
+HF_SUMMARIZER_URL = "https://api-inference.huggingface.co/models/knkarthick/MEETING_SUMMARY"
 HEADERS = {"Authorization": f"Bearer {HF_API_TOKEN}"}
 
 def fetch_text_from_url(url: str) -> str:

--- a/app.py
+++ b/app.py
@@ -42,11 +42,16 @@ def fetch_text_from_url(url: str) -> str:
 def get_embedding(text: str) -> list:
     try:
         response = requests.post(HF_EMBEDDING_URL, headers=HEADERS, json={"inputs": text[:500]})
+        print(f"[HF DEBUG] Status: {response.status_code}")
         if response.status_code == 200:
-            return response.json()[0]  # список флоатов
+            output = response.json()
+            print(f"[HF DEBUG] Output sample: {output[0][:5] if isinstance(output, list) else output}")
+            return output[0] if isinstance(output, list) else []
         else:
+            print(f"[HF ERROR] {response.text}")
             return []
-    except:
+    except Exception as e:
+        print(f"[HF EXCEPTION] {e}")
         return []
 
 
@@ -63,12 +68,14 @@ def search_google_news(text: str) -> list:
     query = quote(text[:100])
     url = f"https://news.google.com/rss/search?q={query}&hl=ru&gl=KZ&ceid=KZ:ru"
     feed = feedparser.parse(url)
+    print(f"[RSS DEBUG] Найдено {len(feed.entries)} публикаций по запросу: {query}")
     return feed.entries
 
 
 def process_semantic_search(article_text: str) -> pd.DataFrame:
     base_embed = get_embedding(article_text)
     if not base_embed:
+        st.warning("Embedding пустой. Проверь API или токен.")
         return pd.DataFrame()
 
     records = []
@@ -84,11 +91,13 @@ def process_semantic_search(article_text: str) -> pd.DataFrame:
         if not pub_date or (datetime.now() - pub_date.replace(tzinfo=None) > timedelta(days=3)):
             continue
         fetched = fetch_text_from_url(link)
+        print(f"[PARSE DEBUG] Длина текста с {link}: {len(fetched)}")
         if not fetched or len(fetched) < 100:
             continue
         cmp_embed = get_embedding(fetched[:500])
         sim = cosine_similarity(base_embed, cmp_embed)
-        if sim < 0.5:
+        print(f"[SIM DEBUG] Сходство с '{entry.get('title', '')[:40]}...': {sim:.4f}")
+        if sim < 0.3:
             continue
         records.append({
             'Источник': urlparse(link).netloc,

--- a/app.py
+++ b/app.py
@@ -4,11 +4,8 @@ from bs4 import BeautifulSoup
 import feedparser
 import pandas as pd
 from urllib.parse import urlparse, quote
-from difflib import SequenceMatcher
-import dateparser
-from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
 from datetime import datetime, timedelta
-import re
+import dateparser
 import os
 import json
 import dotenv
@@ -17,13 +14,9 @@ import dotenv
 dotenv.load_dotenv()
 HF_API_TOKEN = os.getenv("HF_API_TOKEN")
 
-# Встроенные стоп-слова
-RUSSIAN_STOPWORDS = [
-    "и", "в", "во", "не", "что", "он", "на", "я", "с", "со", "как",
-    "а", "то", "все", "она", "так", "его", "но", "да", "ты", "к",
-    "у", "же", "вы", "за", "бы", "по", "только", "ее", "мне", "было",
-    "вот", "от", "меня", "еще", "нет", "о", "из", "ему", "теперь"
-]
+HF_EMBEDDING_URL = "https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+HEADERS = {"Authorization": f"Bearer {HF_API_TOKEN}"}
+
 
 def fetch_text_from_url(url: str) -> str:
     try:
@@ -45,68 +38,76 @@ def fetch_text_from_url(url: str) -> str:
     except:
         return ""
 
-def summarize_text_with_hf(text: str) -> str:
-    url = "https://api-inference.huggingface.co/models/facebook/bart-large-cnn"
-    headers = {"Authorization": f"Bearer {HF_API_TOKEN}"}
-    payload = {"inputs": text[:1024]}  # BART ограничен по длине
-    try:
-        response = requests.post(url, headers=headers, json=payload, timeout=30)
-        result = response.json()
-        return result[0]["summary_text"] if isinstance(result, list) else ""
-    except:
-        return ""
 
-def extract_phrases_tfidf(text: str, n: int = 7) -> list:
+def get_embedding(text: str) -> list:
     try:
-        sentences = [s.strip() for s in text.split('.') if len(s.strip().split()) > 3]
-        if len(sentences) < 2:
-            sentences = [text, text]
-        vectorizer = CountVectorizer(stop_words=RUSSIAN_STOPWORDS, ngram_range=(1, 2))
-        counts = vectorizer.fit_transform(sentences)
-        tfidf = TfidfTransformer().fit_transform(counts)
-        scores = tfidf.toarray().sum(axis=0)
-        terms = vectorizer.get_feature_names_out()
-        sorted_items = sorted(zip(terms, scores), key=lambda x: x[1], reverse=True)
-        return [term for term, _ in sorted_items[:n]]
+        response = requests.post(HF_EMBEDDING_URL, headers=HEADERS, json={"inputs": text[:500]})
+        if response.status_code == 200:
+            return response.json()[0]  # список флоатов
+        else:
+            return []
     except:
         return []
 
-def search_google_news(phrase: str) -> list:
-    url = f"https://news.google.com/rss/search?q={quote(phrase)}&hl=ru&gl=KZ&ceid=KZ:ru"
-    return feedparser.parse(url).entries
 
-def compute_similarity(text1: str, text2: str) -> float:
-    return SequenceMatcher(None, text1, text2).ratio()
+def cosine_similarity(a, b):
+    if not a or not b or len(a) != len(b):
+        return 0
+    dot = sum(i*j for i, j in zip(a, b))
+    norm_a = sum(i*i for i in a) ** 0.5
+    norm_b = sum(i*i for i in b) ** 0.5
+    return dot / (norm_a * norm_b + 1e-8)
 
-def process_search(article_text: str, phrases: list) -> pd.DataFrame:
+
+def search_google_news(text: str) -> list:
+    query = quote(text[:100])
+    url = f"https://news.google.com/rss/search?q={query}&hl=ru&gl=KZ&ceid=KZ:ru"
+    feed = feedparser.parse(url)
+    return feed.entries
+
+
+def process_semantic_search(article_text: str) -> pd.DataFrame:
+    base_embed = get_embedding(article_text)
+    if not base_embed:
+        return pd.DataFrame()
+
     records = []
     seen = set()
-    for phrase in phrases:
-        for entry in search_google_news(phrase)[:10]:
-            link = entry.get('link')
-            if not link or link in seen:
-                continue
-            seen.add(link)
-            pub_date = dateparser.parse(entry.get('published', ''))
-            if not pub_date or (datetime.now() - pub_date.replace(tzinfo=None) > timedelta(days=3)):
-                continue
-            fetched = fetch_text_from_url(link)
-            if not fetched:
-                continue
-            sim = compute_similarity(article_text, fetched)
-            if sim < 0.3:
-                continue
-            records.append({
-                'Источник': urlparse(link).netloc,
-                'Дата': pub_date.strftime('%Y-%m-%d %H:%M') if pub_date else '',
-                'Сходство': f"{sim*100:.1f}%",
-                'Заголовок': entry.get('title', ''),
-                'Ссылка': link
-            })
-    return pd.DataFrame(records)
+    entries = search_google_news(article_text)
+
+    for entry in entries[:20]:
+        link = entry.get('link')
+        if not link or link in seen:
+            continue
+        seen.add(link)
+        pub_date = dateparser.parse(entry.get('published', ''))
+        if not pub_date or (datetime.now() - pub_date.replace(tzinfo=None) > timedelta(days=3)):
+            continue
+        fetched = fetch_text_from_url(link)
+        if not fetched or len(fetched) < 100:
+            continue
+        cmp_embed = get_embedding(fetched[:500])
+        sim = cosine_similarity(base_embed, cmp_embed)
+        if sim < 0.5:
+            continue
+        records.append({
+            'Источник': urlparse(link).netloc,
+            'Дата': pub_date.strftime('%Y-%m-%d %H:%M') if pub_date else '',
+            'Сходство': f"{sim*100:.1f}%",
+            'Заголовок': entry.get('title', ''),
+            'Ссылка': link,
+            'similarity_value': sim,
+            'date_value': pub_date
+        })
+    df = pd.DataFrame(records)
+    if not df.empty:
+        df = df.sort_values(by=['similarity_value', 'date_value'], ascending=[False, True])
+        df = df.drop(columns=['similarity_value', 'date_value'])
+    return df
+
 
 # Streamlit UI
-st.title('📌 ИИ-анализ публикации и поиск похожих новостей')
+st.title('🧠 Семантический поиск похожих публикаций (на ИИ)')
 url = st.text_input('Ссылка на статью')
 text = st.text_area('Или вставьте текст публикации')
 if st.button('Анализ и поиск'):
@@ -117,14 +118,8 @@ if st.button('Анализ и поиск'):
     if not raw:
         st.error('Не удалось получить текст')
     else:
-        st.info('Суммаризация...')
-        summary = summarize_text_with_hf(raw)
-        st.write('📝 Суть текста:', summary)
-        st.info('Извлечение ключевых фраз...')
-        phrases = extract_phrases_tfidf(summary)
-        st.write('📌 Ключевые фразы:', ', '.join(phrases))
-        st.info('Поиск похожих публикаций...')
-        df = process_search(summary, phrases)
+        st.info('Получение смыслового представления текста...')
+        df = process_semantic_search(raw)
         if df.empty:
             st.warning('Похожие публикации не найдены')
         else:

--- a/app.py
+++ b/app.py
@@ -15,8 +15,8 @@ dotenv.load_dotenv()
 HF_API_TOKEN = os.getenv("HF_API_TOKEN")
 
 # Endpoints
-HF_EMBEDDING_URL = "https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
-HF_SUMMARIZER_URL = "https://api-inference.huggingface.co/models/facebook/bart-large-cnn"
+HF_EMBEDDING_URL = "https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/all-MiniLM-L6-v2"
+HF_SUMMARIZER_URL = "https://api-inference.huggingface.co/models/csebuetnlp/mT5_multilingual_XLSum"
 HEADERS = {"Authorization": f"Bearer {HF_API_TOKEN}"}
 
 def fetch_text_from_url(url: str) -> str:

--- a/app.py
+++ b/app.py
@@ -4,99 +4,128 @@ from bs4 import BeautifulSoup
 import feedparser
 import pandas as pd
 from urllib.parse import urlparse, quote
-from datetime import datetime, timedelta
-from sentence_transformers import SentenceTransformer, util
-import torch
+from difflib import SequenceMatcher
 import dateparser
+from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
+from datetime import datetime, timedelta
+import re
 import os
-from dotenv import load_dotenv
+import json
+import dotenv
 
-# Загружаем токен из .env
-load_dotenv()
-HF_TOKEN = os.getenv("HF_TOKEN")
+# Загрузка токена из .env
+dotenv.load_dotenv()
+HF_API_TOKEN = os.getenv("HF_API_TOKEN")
 
-# Загружаем модель
-model = SentenceTransformer("sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2", use_auth_token=HF_TOKEN)
-
+# Встроенные стоп-слова
+RUSSIAN_STOPWORDS = [
+    "и", "в", "во", "не", "что", "он", "на", "я", "с", "со", "как",
+    "а", "то", "все", "она", "так", "его", "но", "да", "ты", "к",
+    "у", "же", "вы", "за", "бы", "по", "только", "ее", "мне", "было",
+    "вот", "от", "меня", "еще", "нет", "о", "из", "ему", "теперь"
+]
 
 def fetch_text_from_url(url: str) -> str:
     try:
         response = requests.get(url, timeout=10)
-    except Exception:
+        if response.status_code != 200:
+            return ""
+        soup = BeautifulSoup(response.text, 'html.parser')
+        texts = []
+        for tag in ['title']:
+            t = soup.find(tag)
+            if t and t.text:
+                texts.append(t.text)
+        for meta in ['description', 'og:description', 'og:title']:
+            tag = soup.find('meta', attrs={'name': meta}) or soup.find('meta', attrs={'property': meta})
+            if tag and tag.get('content'):
+                texts.append(tag['content'])
+        texts += [p.get_text(strip=True) for p in soup.find_all('p')]
+        return '\n'.join(texts)
+    except:
         return ""
-    if response.status_code != 200:
+
+def summarize_text_with_hf(text: str) -> str:
+    url = "https://api-inference.huggingface.co/models/facebook/bart-large-cnn"
+    headers = {"Authorization": f"Bearer {HF_API_TOKEN}"}
+    payload = {"inputs": text[:1024]}  # BART ограничен по длине
+    try:
+        response = requests.post(url, headers=headers, json=payload, timeout=30)
+        result = response.json()
+        return result[0]["summary_text"] if isinstance(result, list) else ""
+    except:
         return ""
-    soup = BeautifulSoup(response.text, 'html.parser')
-    texts = []
-    title = soup.find('title')
-    if title and title.text:
-        texts.append(title.text)
-    for meta in ['description', 'og:description', 'og:title']:
-        tag = soup.find('meta', attrs={'name': meta}) or soup.find('meta', attrs={'property': meta})
-        if tag and tag.get('content'):
-            texts.append(tag['content'])
-    paragraphs = [p.get_text(strip=True) for p in soup.find_all('p')]
-    texts.extend(paragraphs)
-    return '\n'.join(texts)
 
+def extract_phrases_tfidf(text: str, n: int = 7) -> list:
+    try:
+        sentences = [s.strip() for s in text.split('.') if len(s.strip().split()) > 3]
+        if len(sentences) < 2:
+            sentences = [text, text]
+        vectorizer = CountVectorizer(stop_words=RUSSIAN_STOPWORDS, ngram_range=(1, 2))
+        counts = vectorizer.fit_transform(sentences)
+        tfidf = TfidfTransformer().fit_transform(counts)
+        scores = tfidf.toarray().sum(axis=0)
+        terms = vectorizer.get_feature_names_out()
+        sorted_items = sorted(zip(terms, scores), key=lambda x: x[1], reverse=True)
+        return [term for term, _ in sorted_items[:n]]
+    except:
+        return []
 
-def search_google_news(text: str) -> list:
-    query = quote(text)
-    url = f"https://news.google.com/rss/search?q={query}&hl=ru&gl=KZ&ceid=KZ:ru"
-    feed = feedparser.parse(url)
-    return feed.entries
+def search_google_news(phrase: str) -> list:
+    url = f"https://news.google.com/rss/search?q={quote(phrase)}&hl=ru&gl=KZ&ceid=KZ:ru"
+    return feedparser.parse(url).entries
 
+def compute_similarity(text1: str, text2: str) -> float:
+    return SequenceMatcher(None, text1, text2).ratio()
 
-def compare_articles(original_text: str, entries: list) -> pd.DataFrame:
+def process_search(article_text: str, phrases: list) -> pd.DataFrame:
     records = []
-    original_embedding = model.encode(original_text, convert_to_tensor=True)
-    for entry in entries:
-        link = entry.get('link')
-        if not link:
-            continue
-        published = entry.get('published', '')
-        date = dateparser.parse(published)
-        if not date or (datetime.now() - date.replace(tzinfo=None) > timedelta(days=3)):
-            continue
-        candidate_text = fetch_text_from_url(link)
-        if not candidate_text:
-            continue
-        candidate_embedding = model.encode(candidate_text, convert_to_tensor=True)
-        similarity = float(util.pytorch_cos_sim(original_embedding, candidate_embedding)[0][0])
-        if similarity < 0.5:
-            continue
-        records.append({
-            'Источник': urlparse(link).netloc,
-            'Дата': date.strftime('%Y-%m-%d %H:%M'),
-            'Сходство': f"{similarity * 100:.1f}%",
-            'Заголовок': entry.get('title', ''),
-            'Ссылка': link,
-            'similarity_value': similarity,
-            'date_value': date
-        })
-    df = pd.DataFrame(records)
-    if not df.empty:
-        df = df.sort_values(by=['similarity_value', 'date_value'], ascending=[False, True])
-        df = df.drop(columns=['similarity_value', 'date_value'])
-    return df
+    seen = set()
+    for phrase in phrases:
+        for entry in search_google_news(phrase)[:10]:
+            link = entry.get('link')
+            if not link or link in seen:
+                continue
+            seen.add(link)
+            pub_date = dateparser.parse(entry.get('published', ''))
+            if not pub_date or (datetime.now() - pub_date.replace(tzinfo=None) > timedelta(days=3)):
+                continue
+            fetched = fetch_text_from_url(link)
+            if not fetched:
+                continue
+            sim = compute_similarity(article_text, fetched)
+            if sim < 0.3:
+                continue
+            records.append({
+                'Источник': urlparse(link).netloc,
+                'Дата': pub_date.strftime('%Y-%m-%d %H:%M') if pub_date else '',
+                'Сходство': f"{sim*100:.1f}%",
+                'Заголовок': entry.get('title', ''),
+                'Ссылка': link
+            })
+    return pd.DataFrame(records)
 
-
-# UI
-st.title('🧠 Семантический поиск похожих публикаций')
-input_url = st.text_input('Ссылка на статью')
-input_text = st.text_area('Или вставьте текст публикации')
-
-if st.button('Найти похожие материалы'):
-    article_text = input_text.strip()
-    if not article_text and input_url:
-        st.info('Парсинг статьи...')
-        article_text = fetch_text_from_url(input_url)
-    if not article_text:
-        st.error('Не удалось получить текст для анализа')
+# Streamlit UI
+st.title('📌 ИИ-анализ публикации и поиск похожих новостей')
+url = st.text_input('Ссылка на статью')
+text = st.text_area('Или вставьте текст публикации')
+if st.button('Анализ и поиск'):
+    raw = text.strip()
+    if not raw and url:
+        st.info('Парсинг текста...')
+        raw = fetch_text_from_url(url)
+    if not raw:
+        st.error('Не удалось получить текст')
     else:
+        st.info('Суммаризация...')
+        summary = summarize_text_with_hf(raw)
+        st.write('📝 Суть текста:', summary)
+        st.info('Извлечение ключевых фраз...')
+        phrases = extract_phrases_tfidf(summary)
+        st.write('📌 Ключевые фразы:', ', '.join(phrases))
         st.info('Поиск похожих публикаций...')
-        results = compare_articles(article_text, search_google_news(article_text))
-        if results.empty:
+        df = process_search(summary, phrases)
+        if df.empty:
             st.warning('Похожие публикации не найдены')
         else:
-            st.dataframe(results)
+            st.dataframe(df)

--- a/app.py
+++ b/app.py
@@ -4,21 +4,20 @@ from bs4 import BeautifulSoup
 import feedparser
 import pandas as pd
 from urllib.parse import urlparse, quote
-from difflib import SequenceMatcher
-import dateparser
-from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
-import re
 from datetime import datetime, timedelta
+from sentence_transformers import SentenceTransformer, util
+import torch
+import dateparser
+import os
+from dotenv import load_dotenv
 
-# Встроенный список русских стоп-слов
-RUSSIAN_STOPWORDS = [
-    "и", "в", "во", "не", "что", "он", "на", "я", "с", "со", "как",
-    "а", "то", "все", "она", "так", "его", "но", "да", "ты", "к",
-    "у", "же", "вы", "за", "бы", "по", "только", "ее", "мне", "было",
-    "вот", "от", "меня", "еще", "нет", "о", "из", "ему", "теперь"
-]
+# Загружаем токен из .env
+load_dotenv()
+HF_TOKEN = os.getenv("HF_TOKEN")
 
-USE_KEYBERT = False  # Отключено — не используется на Python 3.13
+# Загружаем модель
+model = SentenceTransformer("sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2", use_auth_token=HF_TOKEN)
+
 
 def fetch_text_from_url(url: str) -> str:
     try:
@@ -41,136 +40,53 @@ def fetch_text_from_url(url: str) -> str:
     return '\n'.join(texts)
 
 
-def extract_additional_phrases(text: str) -> list:
-    """Extract simple patterns from short news text."""
-    extra = []
-    # фамилия + должность
-    for m in re.findall(r"([А-ЯЁ][а-яё]+)\s+(?:[\w-]+\s+)?(президент|премьер|министр|глава|депутат|сенатор|мэр|губернатор|директор|председатель)", text, flags=re.I):
-        extra.append(f"{m[0]} {m[1]}")
-    # встреча A и B
-    for m in re.findall(r"встреча\s+([А-ЯЁ][а-яё]+)\s+и\s+([А-ЯЁ][а-яё]+)", text, flags=re.I):
-        extra.append(f"встреча {m[0]} и {m[1]}")
-    # визит в город
-    for m in re.findall(r"визит\s+в\s+([А-ЯЁ][а-яё]+)", text, flags=re.I):
-        extra.append(f"визит в {m}")
-    return extra
-
-
-def filter_noise_phrases(phrases: list) -> list:
-    banned_words = {"президента", "казахстана", "владимира"}
-    endings = ("а", "я", "у", "ю", "е", "о", "ом", "ой", "ем", "ам", "ях", "ью", "ов", "ев")
-    result = []
-    for p in phrases:
-        words = p.split()
-        if len(words) == 1:
-            w = words[0].lower()
-            if w in banned_words:
-                continue
-            if len(w) < 5 or w.endswith(endings):
-                continue
-        result.append(p)
-    return result
-
-
-def extract_key_phrases(text: str, n: int = 5) -> list:
-    try:
-        if len(text.strip().split()) < 10:
-            return []
-
-        sentences = [s.strip() for s in text.split('.') if len(s.strip().split()) > 3]
-        if len(sentences) < 2:
-            sentences = [text, text]
-
-        vectorizer = CountVectorizer(stop_words=RUSSIAN_STOPWORDS, ngram_range=(1, 2))
-        counts = vectorizer.fit_transform(sentences)
-
-        if counts.shape[1] == 0:
-            return []
-
-        tfidf = TfidfTransformer().fit_transform(counts)
-        scores = tfidf.toarray().sum(axis=0)
-        terms = vectorizer.get_feature_names_out()
-        sorted_items = sorted(zip(terms, scores), key=lambda x: x[1], reverse=True)
-        phrases = [term for term, _ in sorted_items[:n]]
-        # manually expand phrases for short texts
-        if len(text.split()) < 100:
-            extras = extract_additional_phrases(text)
-            if extras:
-                phrases.extend(extras)
-        phrases = list(dict.fromkeys(filter_noise_phrases(phrases)))
-        return phrases
-    except Exception as e:
-        print(f"[ERROR in extract_key_phrases]: {e}")
-        return []
-
-
-def search_google_news(phrase: str) -> list:
-    query = quote(phrase)
+def search_google_news(text: str) -> list:
+    query = quote(text)
     url = f"https://news.google.com/rss/search?q={query}&hl=ru&gl=KZ&ceid=KZ:ru"
     feed = feedparser.parse(url)
     return feed.entries
 
 
-def compute_similarity(text1: str, text2: str) -> float:
-    matcher = SequenceMatcher(None, text1, text2)
-    return matcher.ratio()
-
-
-def process_search(article_text: str, phrases: list) -> pd.DataFrame:
+def compare_articles(original_text: str, entries: list) -> pd.DataFrame:
     records = []
-    seen_urls = set()
-    unique_phrases = list({p for p in phrases if len(p.strip()) > 2})
-
-    for phrase in unique_phrases:
-        entries = search_google_news(phrase)
-        print(f"[🔍 Поиск]: \"{phrase}\" → найдено {len(entries)} результатов")
-        for e in entries[:5]:
-            print(f"    → {e.get('title')} — {e.get('link')}")
-        for entry in entries[:10]:
-            link = entry.get('link')
-            if not link or link in seen_urls:
-                continue
-            seen_urls.add(link)
-            published = entry.get('published', '')
-            if not published:
-                continue
-            date = dateparser.parse(published)
-            if not date:
-                continue
-            if date and datetime.now() - date.replace(tzinfo=None) > timedelta(days=3):
-                continue
-            snippet = entry.get('title', '')
-            fetched_text = fetch_text_from_url(link)
-            if not fetched_text:
-                continue
-            similarity = compute_similarity(article_text, fetched_text)
-            print(f"→ Заголовок: {snippet}")
-            print(f"→ Сходство: {similarity:.3f}")
-            if similarity < 0.3:
-                continue
-            records.append({
-                'Источник': urlparse(link).netloc,
-                'Дата': date.strftime('%Y-%m-%d %H:%M') if date else '',
-                'Сходство': f"{similarity*100:.1f}%",
-                'Заголовок': snippet,
-                'Ссылка': link,
-                'similarity_value': similarity,
-                'date_value': date or dateparser.parse('1970-01-01')
-            })
+    original_embedding = model.encode(original_text, convert_to_tensor=True)
+    for entry in entries:
+        link = entry.get('link')
+        if not link:
+            continue
+        published = entry.get('published', '')
+        date = dateparser.parse(published)
+        if not date or (datetime.now() - date.replace(tzinfo=None) > timedelta(days=3)):
+            continue
+        candidate_text = fetch_text_from_url(link)
+        if not candidate_text:
+            continue
+        candidate_embedding = model.encode(candidate_text, convert_to_tensor=True)
+        similarity = float(util.pytorch_cos_sim(original_embedding, candidate_embedding)[0][0])
+        if similarity < 0.5:
+            continue
+        records.append({
+            'Источник': urlparse(link).netloc,
+            'Дата': date.strftime('%Y-%m-%d %H:%M'),
+            'Сходство': f"{similarity * 100:.1f}%",
+            'Заголовок': entry.get('title', ''),
+            'Ссылка': link,
+            'similarity_value': similarity,
+            'date_value': date
+        })
     df = pd.DataFrame(records)
-    if df.empty:
-        return df
-    df = df.sort_values(by=['similarity_value', 'date_value'], ascending=[False, True])
-    return df.drop(columns=['similarity_value', 'date_value'])
+    if not df.empty:
+        df = df.sort_values(by=['similarity_value', 'date_value'], ascending=[False, True])
+        df = df.drop(columns=['similarity_value', 'date_value'])
+    return df
 
 
-# Streamlit UI
-st.title('🔍 Определение первоисточника публикации')
-
+# UI
+st.title('🧠 Семантический поиск похожих публикаций')
 input_url = st.text_input('Ссылка на статью')
 input_text = st.text_area('Или вставьте текст публикации')
 
-if st.button('Найти первоисточник'):
+if st.button('Найти похожие материалы'):
     article_text = input_text.strip()
     if not article_text and input_url:
         st.info('Парсинг статьи...')
@@ -178,15 +94,9 @@ if st.button('Найти первоисточник'):
     if not article_text:
         st.error('Не удалось получить текст для анализа')
     else:
-        st.info('Извлечение ключевых фраз...')
-        phrases = extract_key_phrases(article_text, 7)
-        if not phrases:
-            st.error('Не удалось извлечь ключевые фразы')
+        st.info('Поиск похожих публикаций...')
+        results = compare_articles(article_text, search_google_news(article_text))
+        if results.empty:
+            st.warning('Похожие публикации не найдены')
         else:
-            st.write('Ключевые фразы:', ', '.join(phrases))
-            st.info('Поиск похожих публикаций...')
-            results = process_search(article_text, phrases)
-            if results.empty:
-                st.warning('Похожие публикации не найдены')
-            else:
-                st.dataframe(results)
+            st.dataframe(results)

--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ HF_API_TOKEN = os.getenv("HF_API_TOKEN")
 
 # Endpoints
 HF_EMBEDDING_URL = "https://api-inference.huggingface.co/models/sentence-transformers/all-MiniLM-L6-v2"
-HF_SUMMARIZER_URL = "https://api-inference.huggingface.co/models/knkarthick/MEETING_SUMMARY"
+HF_SUMMARIZER_URL = "https://api-inference.huggingface.co/models/facebook/bart-large-cnn"
 HEADERS = {"Authorization": f"Bearer {HF_API_TOKEN}"}
 
 def fetch_text_from_url(url: str) -> str:

--- a/app.py
+++ b/app.py
@@ -30,20 +30,41 @@ def fetch_text_from_url(url: str) -> str:
         return ""
 
 def summarize_text(text: str) -> str:
+    cleaned = text.strip().replace('\n', ' ')
+    words = cleaned.split()
+    word_count = len(words)
+    print(f"[SUMMARY] Word count: {word_count}")
+
+    if word_count < 30:
+        print("[SUMMARY FALLBACK] Текст слишком короткий, возвращаем как есть.")
+        return cleaned
+
+    if word_count > 800:
+        print(f"[SUMMARY TRUNCATED] Исходный текст обрезан с {word_count} до 800 слов.")
+        cleaned = ' '.join(words[:800])
+
     try:
-        response = requests.post(HF_SUMMARIZER_URL, headers=HEADERS, json={"inputs": text[:1024]})
+        response = requests.post(HF_SUMMARIZER_URL, headers=HEADERS, json={"inputs": cleaned})
+        print(f"[SUMMARY STATUS] {response.status_code}")
         if response.status_code == 200:
-            return response.json()[0]['summary_text']
+            result = response.json()
+            if isinstance(result, list) and result and 'summary_text' in result[0]:
+                print("[SUMMARY OK]", result[0]['summary_text'][:100])
+                return result[0]['summary_text']
+            else:
+                print(f"[SUMMARY FORMAT ERROR] {result}")
+                return cleaned
         else:
             print(f"[SUMMARY ERROR] {response.text}")
-            return ""
+            return cleaned
     except Exception as e:
         print(f"[SUMMARY EXCEPTION] {e}")
-        return ""
+        return cleaned
 
 def get_embedding(text: str) -> list:
     try:
         response = requests.post(HF_EMBEDDING_URL, headers=HEADERS, json={"inputs": text[:512]})
+        print(f"[EMBEDDING STATUS] {response.status_code}")
         if response.status_code == 200:
             return response.json()[0]
         else:
@@ -69,6 +90,7 @@ def search_google_news(query: str) -> list:
     return feed.entries
 
 def process_semantic_search(article_text: str) -> pd.DataFrame:
+    print("[PROCESS] Запуск обработки статьи...")
     summary = summarize_text(article_text)
     if not summary:
         st.warning("Не удалось сделать краткое содержание текста")
@@ -92,10 +114,12 @@ def process_semantic_search(article_text: str) -> pd.DataFrame:
         if not pub_date or (datetime.now() - pub_date.replace(tzinfo=None) > timedelta(days=5)):
             continue
         fetched = fetch_text_from_url(link)
+        print(f"[PARSE DEBUG] {link} -> {len(fetched)} символов")
         if not fetched or len(fetched) < 100:
             continue
         cmp_embed = get_embedding(fetched)
         sim = cosine_similarity(base_embed, cmp_embed)
+        print(f"[SIM DEBUG] Сходство с '{entry.get('title', '')[:40]}...': {sim:.4f}")
         if sim < 0.3:
             continue
         records.append({

--- a/app.py
+++ b/app.py
@@ -137,7 +137,7 @@ def process_search(article_text: str, phrases: list) -> pd.DataFrame:
             date = dateparser.parse(published)
             if not date:
                 continue
-            if datetime.now() - date > timedelta(days=3):
+            if date and datetime.now() - date.replace(tzinfo=None) > timedelta(days=3):
                 continue
             snippet = entry.get('title', '')
             fetched_text = fetch_text_from_url(link)

--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ import dotenv
 dotenv.load_dotenv()
 HF_API_TOKEN = os.getenv("HF_API_TOKEN")
 
-HF_EMBEDDING_URL = "https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+HF_EMBEDDING_URL = "https://api-inference.huggingface.co/models/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 HEADERS = {"Authorization": f"Bearer {HF_API_TOKEN}"}
 
 
@@ -41,6 +41,9 @@ def fetch_text_from_url(url: str) -> str:
 
 def get_embedding(text: str) -> list:
     try:
+        print(f"[DEBUG] token loaded: {HF_API_TOKEN[:10]}")
+        print(f"[DEBUG] headers: {HEADERS}")
+        print(f"[DEBUG] sample input: {text[:100]}")
         response = requests.post(HF_EMBEDDING_URL, headers=HEADERS, json={"inputs": text[:500]})
         print(f"[HF DEBUG] Status: {response.status_code}")
         if response.status_code == 200:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,7 @@ requests
 beautifulsoup4
 feedparser
 pandas
-dateparser
 scikit-learn
-# The following libraries rely on PyTorch and currently do not
-# provide wheels for Python 3.13. They are optional and used only
-# for improved keyword extraction. When they gain Python 3.13
-# support, you can install them manually:
-# sentence-transformers
-# keybert
-
+python-dotenv
+transformers
+dateparser

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scikit-learn
 python-dotenv
 transformers
 dateparser
+newspaper3k


### PR DESCRIPTION
## Summary
- expand search phrases with simple patterns for short texts
- filter single-word noise phrases
- log search phrases and Google RSS results
- lower similarity threshold
- ignore RSS entries older than three days

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685242b03c4c8327826a2994d7ab48f6